### PR TITLE
Loosen SDF parser to handle SDF files generated by DataWarrior 

### DIFF
--- a/.nx/version-plans/version-plan-1759134623618.md
+++ b/.nx/version-plans/version-plan-1759134623618.md
@@ -1,0 +1,5 @@
+---
+grit-compounds: patch
+---
+
+less strict SDF parser for handling SDF exported via DataWarrior

--- a/modules/compounds/backend/lib/grit/compounds/sdf.rb
+++ b/modules/compounds/backend/lib/grit/compounds/sdf.rb
@@ -45,7 +45,7 @@ module Grit
               record[prop_name] = prop_lines.join("\n")
               prop_name = nil
               prop_lines = []
-            elsif prop_def = /^> <(?<prop_name>\w+)>$/.match(line)
+            elsif prop_def = /^>\s+<(?<prop_name>\w+)>$/.match(line)
               raise Grit::Core::EntityLoader::ParseException.new "Malformed SDF file" unless prop_name.nil?
               prop_name = prop_def[:prop_name]
               prop_names.add(prop_name)


### PR DESCRIPTION
Fix SDF parser to allow prop block headers to contain multiple spaces `>   <PROP_ID>` to successfully parse SDF files generated by DataWarrior.

Test with the file attached in #36 

closes #36