### PR TITLE
Client library classname precedence

### DIFF
--- a/.nx/version-plans/version-plan-1777643587625.md
+++ b/.nx/version-plans/version-plan-1777643587625.md
@@ -1,0 +1,5 @@
+---
+'@grit42/client-library': patch
+---
+
+`Tabs` component `className` applied after default styles

--- a/.nx/version-plans/version-plan-1777887147227.md
+++ b/.nx/version-plans/version-plan-1777887147227.md
@@ -1,0 +1,5 @@
+---
+'@grit42/client-library': patch
+---
+
+`Dialog` component `className` applied after default styles

--- a/packages/frontend/client-library/lib/components/Dialog/index.tsx
+++ b/packages/frontend/client-library/lib/components/Dialog/index.tsx
@@ -161,12 +161,16 @@ const DialogContent = ({
         <div
           ref={ref}
           onKeyDown={handleKeyDown}
-          className={classnames(styles.dialog, className, {
-            [styles.show as string]: showTransition,
-            [styles.withTable as string]: withTable === true,
-            [styles.wide as string]: isWide === true,
-            [styles.fullscreen as string]: isFullscreen === true,
-          })}
+          className={classnames(
+            styles.dialog,
+            {
+              [styles.show as string]: showTransition,
+              [styles.withTable as string]: withTable === true,
+              [styles.wide as string]: isWide === true,
+              [styles.fullscreen as string]: isFullscreen === true,
+            },
+            className,
+          )}
           onTransitionEnd={() => {
             if (transitionState === "out") {
               if (

--- a/packages/frontend/client-library/lib/components/Tabs/index.tsx
+++ b/packages/frontend/client-library/lib/components/Tabs/index.tsx
@@ -110,7 +110,7 @@ const Tabs = ({
           <ReactTabPanel
             {...panelProps}
             key={tab.key}
-            selectedClassName={classnames(className, styles.selectedPanel)}
+            selectedClassName={classnames(styles.selectedPanel, className)}
             className={classnames(styles.panel)}
           >
             {tab.panel}


### PR DESCRIPTION
**Client library classname precedence**

This PR updates the `Tabs` and `Dialog` components to apply the CSS class provided by props after the default styles.