### PR TITLE
ActiveRecord Relation index sort order precedence

### DIFF
--- a/.nx/version-plans/version-plan-1777642986668.md
+++ b/.nx/version-plans/version-plan-1777642986668.md
@@ -1,0 +1,5 @@
+---
+grit-core: patch
+---
+
+active record relation sort precedence

--- a/modules/core/backend/app/controllers/concerns/grit/core/grit_entity_controller.rb
+++ b/modules/core/backend/app/controllers/concerns/grit/core/grit_entity_controller.rb
@@ -79,11 +79,13 @@ module Grit::Core::GritEntityController
         end
       end
 
+
+      default_order_values = scope.order_values
+      scope = scope.unscope(:order)
       sort.each do |sort_item|
-        default_order_values = scope.order_values
-        scope = scope.reorder(ActiveRecord::Base.send(:sanitize_sql_array, [ "#{select_values_map[sort_item["property"]]} #{sort_item["direction"]} NULLS LAST" ]))
-        scope.order_values = [ *scope.order_values, *default_order_values ]
+        scope = scope.order(ActiveRecord::Base.send(:sanitize_sql_array, [ "#{select_values_map[sort_item["property"]]} #{sort_item["direction"]} NULLS LAST" ]))
       end
+      scope.order_values = [ *scope.order_values, *default_order_values ]
 
       filter.each do |filter_item|
         scope = scope.where(Grit::Core::FilterProvider.execute(filter_item["type"], filter_item["operator"], select_values_map[filter_item["property"]], filter_item["value"]))


### PR DESCRIPTION
**ActiveRecord Relation index sort order precedence**

This PR fixes the generic sorting of ActiveRecord Relations to not reverse the ordering of sort items when the relation is sorted by multiple properties.

With sort: 
```js
[{property: "name", direction: "ASC},{property: "origin_id", direction: "ASC}]
```

Resulting SQL order before: 
```sql
[...] ORDER BY origin_id ASC, name ASC [...]
```

Resulting SQL order after: 
```sql
[...] ORDER BY name ASC, origin_id ASC [...]
```