### PR TITLE
GritEntityController overridable model

### DIFF
--- a/modules/core/backend/app/controllers/concerns/grit/core/grit_entity_controller.rb
+++ b/modules/core/backend/app/controllers/concerns/grit/core/grit_entity_controller.rb
@@ -54,7 +54,7 @@ module Grit::Core::GritEntityController
     end
 
     def filter_and_sort_raw_sql(scope, filter, sort)
-      klass = controller_path.classify.constantize
+      klass = self.get_model(params)
 
       scope = klass.unscoped.select("sub.*").from("(#{scope}) sub")
 
@@ -127,7 +127,8 @@ module Grit::Core::GritEntityController
     def csv_from_query(query)
       csv_sql = "COPY (#{query.to_sql}) TO STDOUT WITH DELIMITER ',' CSV HEADER"
 
-      temp_file = Tempfile.new("#{controller_path.classify.demodulize.underscore}.csv")
+      klass = self.get_model(params)
+      temp_file = Tempfile.new("#{klass.name.demodulize.underscore}.csv")
 
       ActiveRecord::Base.connection.raw_connection.copy_data(csv_sql) do
         row = ActiveRecord::Base.connection.raw_connection.get_copy_data
@@ -146,7 +147,8 @@ module Grit::Core::GritEntityController
     end
 
     def export_file_name
-      "#{controller_path.classify.demodulize.underscore}.csv"
+      klass = self.get_model(params)
+      "#{klass.name.demodulize.underscore}.csv"
     end
 
     def export
@@ -154,7 +156,7 @@ module Grit::Core::GritEntityController
       return if query.nil?
 
       if params[:columns]&.length
-        klass = controller_path.classify.constantize
+        klass = self.get_model(params)
         query = klass.unscoped.select(*params[:columns]).from(query, :sub)
       end
 
@@ -170,7 +172,8 @@ module Grit::Core::GritEntityController
     end
 
     def show_new_entity
-      controller_path.classify.constantize.new()
+      klass = self.get_model(params)
+      klass.new()
     end
 
     def show_entity(params)
@@ -195,7 +198,7 @@ module Grit::Core::GritEntityController
     end
 
     def create
-      klass = controller_path.classify.constantize
+      klass = self.get_model(params)
       permitted_params = params.permit(self.permitted_params)
       @record = klass.new(permitted_params)
 
@@ -211,7 +214,7 @@ module Grit::Core::GritEntityController
     end
 
     def update
-      klass = controller_path.classify.constantize
+      klass = self.get_model(params)
       @record = klass.find(params[:id])
       permitted_params = params.permit(self.permitted_params)
 
@@ -229,7 +232,7 @@ module Grit::Core::GritEntityController
     end
 
     def destroy
-      klass = controller_path.classify.constantize
+      klass = self.get_model(params)
       ids = params[:id] if params[:id] != "destroy"
       ids = params[:ids].split(",") if params[:id] == "destroy"
       klass.where(id: ids).destroy_all
@@ -242,6 +245,11 @@ module Grit::Core::GritEntityController
 
     private
 
+    def get_model(params)
+      return model_override(params) if respond_to?(:model_override)
+      controller_path.classify.constantize
+    end
+
     # Allow Authlogic single_access_token authentication for any request
     # type when a Bearer token or user_credentials param is present.
     # Without this, Authlogic only permits single access for RSS/Atom
@@ -252,29 +260,29 @@ module Grit::Core::GritEntityController
     end
 
     def check_read
-      klass = controller_path.classify.constantize
-      render json: { success: false, errors: "You do not have the permissions required to read #{controller_path.classify}" }, status: :forbidden if klass.entity_crud[:read].nil? or (!klass.entity_crud[:read].length.zero? and !current_user.one_of_these_roles?(klass.entity_crud[:read]))
+      klass = get_model(params)
+      render json: { success: false, errors: "You do not have the permissions required to read #{klass.name}" }, status: :forbidden if klass.entity_crud[:read].nil? or (!klass.entity_crud[:read].length.zero? and !current_user.one_of_these_roles?(klass.entity_crud[:read]))
     end
 
     def check_create
-      klass = controller_path.classify.constantize
-      render json: { success: false, errors: "You do not have the permissions required to create #{controller_path.classify}" }, status: :forbidden if klass.entity_crud[:create].nil? or (!klass.entity_crud[:create].length.zero? and !current_user.one_of_these_roles?(klass.entity_crud[:create]))
+      klass = get_model(params)
+      render json: { success: false, errors: "You do not have the permissions required to create #{klass.name}" }, status: :forbidden if klass.entity_crud[:create].nil? or (!klass.entity_crud[:create].length.zero? and !current_user.one_of_these_roles?(klass.entity_crud[:create]))
     end
 
     def check_update
-      klass = controller_path.classify.constantize
-      render json: { success: false, errors: "You do not have the permissions required to update #{controller_path.classify}" }, status: :forbidden  if klass.entity_crud[:update].nil? or (!klass.entity_crud[:update].length.zero? and !current_user.one_of_these_roles?(klass.entity_crud[:update]))
+      klass = get_model(params)
+      render json: { success: false, errors: "You do not have the permissions required to update #{klass.name}" }, status: :forbidden  if klass.entity_crud[:update].nil? or (!klass.entity_crud[:update].length.zero? and !current_user.one_of_these_roles?(klass.entity_crud[:update]))
     end
 
     def check_destroy
-      klass = controller_path.classify.constantize
-      render json: { success: false, errors: "You do not have the permissions required to delete #{controller_path.classify}" }, status: :forbidden if klass.entity_crud[:destroy].nil? or (!klass.entity_crud[:destroy].length.zero? and !current_user.one_of_these_roles?(klass.entity_crud[:destroy]))
+      klass = get_model(params)
+      render json: { success: false, errors: "You do not have the permissions required to delete #{klass.name}" }, status: :forbidden if klass.entity_crud[:destroy].nil? or (!klass.entity_crud[:destroy].length.zero? and !current_user.one_of_these_roles?(klass.entity_crud[:destroy]))
     end
 
     def get_scope(scope, params)
-      klass = controller_path.classify.constantize
+      klass = get_model(params)
       klass_scope = klass.send(scope, params) if klass.respond_to?(scope)
-      render json: { success: false, errors: "#{controller_path.classify} does not implement scope '#{scope}'" }, status: :bad_request if klass_scope.nil?
+      render json: { success: false, errors: "#{klass.name} does not implement scope '#{scope}'" }, status: :bad_request if klass_scope.nil?
       klass_scope
     end
 

--- a/modules/core/backend/app/models/grit/core/user.rb
+++ b/modules/core/backend/app/models/grit/core/user.rb
@@ -228,9 +228,11 @@ module Grit::Core
     end
 
     def forgot_token_expired?
-      logger.info "nil" if forgot_token_expires_at.nil?
-      logger.info "expired" if forgot_token_expires_at.present? && forgot_token_expires_at < Time.current
       forgot_token_expires_at.nil? || forgot_token_expires_at < Time.current
+    end
+
+    def valid_forgot_token?
+      forgot_token_expires_at.present? && forgot_token_expires_at > Time.current
     end
 
     def record_failed_two_factor_attempt!

--- a/modules/core/backend/spec/requests/grit/core/grit_entity_controller_model_override_spec.rb
+++ b/modules/core/backend/spec/requests/grit/core/grit_entity_controller_model_override_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Copyright 2025 grit42 A/S. <https://grit42.com/>
+#
+# This file is part of @grit42/core.
+#
+# @grit42/core is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or  any later version.
+#
+# @grit42/core is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# @grit42/core. If not, see <https://www.gnu.org/licenses/>.
+
+require "rails_helper"
+
+# Exercises the `get_model` extension point on Grit::Core::GritEntityController.
+# The dummy app's Grit::OverriddenEntitiesController defines `model_override`,
+# but no Grit::OverriddenEntity class exists — so the default
+# `controller_path.classify.constantize` branch would NameError. Successful
+# responses prove the override is wired through every relevant before_action
+# and action.
+RSpec.describe "GritEntityController model_override", type: :request do
+  let(:admin)     { create(:grit_core_user, :admin, :with_admin_role) }
+  let(:non_admin) { create(:grit_core_user) }
+
+  describe "when model_override is defined" do
+    before { login_as(admin) }
+
+    it "resolves the model via override for index" do
+      get "/api/grit/overridden_entities"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "creates records on the overridden model" do
+      expect {
+        post "/api/grit/overridden_entities", params: { name: "x" }, as: :json
+      }.to change(Grit::TestEntity, :count).by(1)
+      expect(response).to have_http_status(:created)
+    end
+
+    it "passes params to model_override and uses klass.name in the forbidden message" do
+      login_as(non_admin)
+      post "/api/grit/overridden_entities", params: { name: "x", as_role: "1" }, as: :json
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body["errors"]).to include("Grit::Core::Role")
+    end
+  end
+
+  describe "when model_override is not defined (default branch)" do
+    before { login_as(admin) }
+
+    it "falls back to controller_path.classify.constantize" do
+      get "/api/grit/test_entities"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/modules/core/backend/spec/requests/grit/core/load_set_blocks_spec.rb
+++ b/modules/core/backend/spec/requests/grit/core/load_set_blocks_spec.rb
@@ -454,10 +454,13 @@ RSpec.describe "Load Set Blocks API", type: :request do
         let(:load_set_block_id) { block.id }
 
         around(:each) do |example|
-          original_adapter = ActiveJob::Base.queue_adapter
+          original_base  = ActiveJob::Base.queue_adapter
+          original_class = Grit::Core::ConfirmLoadSetBlockJob.queue_adapter
           ActiveJob::Base.queue_adapter = :test
+          Grit::Core::ConfirmLoadSetBlockJob.queue_adapter = ActiveJob::Base.queue_adapter
           example.run
-          ActiveJob::Base.queue_adapter = original_adapter
+          Grit::Core::ConfirmLoadSetBlockJob.queue_adapter = original_class
+          ActiveJob::Base.queue_adapter = original_base
         end
 
         it "enqueues a confirmation job and moves the block to Confirming", rswag: false do

--- a/modules/core/backend/spec/requests/grit/core/load_sets_spec.rb
+++ b/modules/core/backend/spec/requests/grit/core/load_sets_spec.rb
@@ -172,10 +172,13 @@ RSpec.describe "Load Sets API", type: :request do
         let(:id) { load_set.id }
 
         around(:each) do |example|
-          original_adapter = ActiveJob::Base.queue_adapter
+          original_base  = ActiveJob::Base.queue_adapter
+          original_class = Grit::Core::InitializeLoadSetBlockJob.queue_adapter
           ActiveJob::Base.queue_adapter = :test
+          Grit::Core::InitializeLoadSetBlockJob.queue_adapter = ActiveJob::Base.queue_adapter
           example.run
-          ActiveJob::Base.queue_adapter = original_adapter
+          Grit::Core::InitializeLoadSetBlockJob.queue_adapter = original_class
+          ActiveJob::Base.queue_adapter = original_base
         end
 
         it "enqueues an initialization job for each block", rswag: false do

--- a/modules/core/backend/spec/requests/grit/core/users_spec.rb
+++ b/modules/core/backend/spec/requests/grit/core/users_spec.rb
@@ -239,6 +239,21 @@ RSpec.describe "Users API", type: :request do
       expect(response).to have_http_status(:success)
     end
 
+    it "should not reset password with expired token" do
+      post "/api/grit/core/user/request_password_reset", params: { user: admin.email }, as: :json
+      expect(response).to have_http_status(:success)
+
+      admin.update_column(:forgot_token_expires_at, 1.hours.ago)
+      admin.reload
+
+      post "/api/grit/core/user/password_reset", params: {
+        forgot_token: admin.forgot_token,
+        password: "testtest",
+        password_confirmation: "testtest"
+      }, as: :json
+      expect(response).to have_http_status(:internal_server_error)
+    end
+
     it "should update password" do
       login_as(notadmin)
       post "/api/grit/core/user/update_password", params: {

--- a/modules/core/backend/test/dummy/app/controllers/grit/overridden_entities_controller.rb
+++ b/modules/core/backend/test/dummy/app/controllers/grit/overridden_entities_controller.rb
@@ -1,0 +1,14 @@
+class Grit::OverriddenEntitiesController < ApplicationController
+  include Grit::Core::GritEntityController
+
+  def model_override(params)
+    return Grit::Core::Role if params[:as_role] == "1"
+    Grit::TestEntity
+  end
+
+  private
+
+  def permitted_params
+    [ "name", "another_string", "integer", "decimal", "float", "text", "datetime", "date", "boolean", "user_id" ]
+  end
+end

--- a/modules/core/backend/test/dummy/config/routes.rb
+++ b/modules/core/backend/test/dummy/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   scope :api do
     namespace :grit do
       resources :test_entities
+      resources :overridden_entities
     end
   end
 end


### PR DESCRIPTION
**GritEntityController overridable model**

This PR adds an extension point to `GritEntityController` to override the model identification behavior to use models unrelated to the controller name or path.